### PR TITLE
Use generic-filehandle base class as type for parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
-import type { FileHandle } from 'fs/promises';
-import type { LocalFile, RemoteFile, BlobFile } from 'generic-filehandle';
+import type { GenericFilehandle } from 'generic-filehandle';
 
-type AnyFile = LocalFile | RemoteFile | BlobFile | FileHandle;
 type ParsedIxx = Map<string, number>;
 
 const trixPrefixSize = 5;
@@ -10,7 +8,7 @@ const trixPrefixSize = 5;
 // Then use the trixSearch() function to search for a word.
 export default class Trix {
   private index: Promise<ParsedIxx>;
-  private ixFile: AnyFile;
+  private ixFile: GenericFilehandle;
   maxResults: number;
 
   /**
@@ -18,7 +16,11 @@ export default class Trix {
    * @param ixFile [anyFile] the first-level trix index file produced by ixIxx.
    * @param maxResults [number] the maximum number of results to return. Default is set to 20.
    */
-  constructor(ixxFile: AnyFile, ixFile: AnyFile, maxResults: number = 20) {
+  constructor(
+    ixxFile: GenericFilehandle,
+    ixFile: GenericFilehandle,
+    maxResults: number = 20
+  ) {
     this.index = this._parseIxx(ixxFile);
     this.ixFile = ixFile;
     this.maxResults = maxResults;
@@ -297,7 +299,7 @@ export default class Trix {
    * @param ixxFile [anyFile] second level index that is produced by ixIxx.
    * @returns a ParsedIxx map.
    */
-  private async _parseIxx(ixxFile: AnyFile): Promise<ParsedIxx> {
+  private async _parseIxx(ixxFile: GenericFilehandle): Promise<ParsedIxx> {
     const ixx = new Map();
 
     // Load the ixxFile into ixxData object


### PR DESCRIPTION
This is a small proposal to use the GenericFilehandle base class type

Currently if I pass, as most adapters use, openLocation(filelocation) to the adapter, it throws a typescript warning

By using the GenericFilehandle base class it should be ok though