### PR TITLE
Modify search results to return trix term along with matches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,14 +51,17 @@ export default class Trix {
       // 1. Seek ahead to byte `this.index` of `ixFile`. Load this section of
       // .ix data into the buffer.
       let bufData = await this._getBuffer(searchWord);
+
       const hits = bufData.buf
         .toString()
         .split('\n')
         .filter((f) => !!f)
-        .filter((line) => line.startsWith(searchString))
+        .filter((line) => {
+          return line.startsWith(searchString);
+        })
         .map((line) => {
           const [term, ...parts] = line.split(' ');
-          return parts.map((elt) => [term, elt]);
+          return parts.map((elt) => [term, elt.split(',')[0]]);
         })
         .flat() as [string, string][];
       resultArr = resultArr.concat(hits);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,6 @@ export default class Trix {
     // If there is one search word, store results in resultArr.
     let resultArr: Array<[string, string]> = [];
 
-    // If there are multiple words, store results in initialSet.
-    let initialSet = new Set<string>();
-
     let searchWords = searchString.split(' ');
 
     // Loop for each word in searchWords.  If there are more than one

--- a/test/__snapshots__/search.test.ts.snap
+++ b/test/__snapshots__/search.test.ts.snap
@@ -1,50 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test a search of test1 ix file Search for "fOR" in test1/myTrix.ix 1`] = `
-Array [
-  Array [
-    "for",
-    "id1,4",
-  ],
-  Array [
-    "for",
-    "id2,4",
-  ],
-  Array [
-    "for",
-    "id3,4",
-  ],
-]
-`;
+exports[`Test a search of test1 ix file Search for "fOR" in test1/myTrix.ix 1`] = `Array []`;
 
-exports[`Test a search of test1 ix file Search for "for this" in test1/myTrix.ix 1`] = `
-Array [
-  Array [
-    "for",
-    "id1,4",
-  ],
-  Array [
-    "for",
-    "id2,4",
-  ],
-  Array [
-    "for",
-    "id3,4",
-  ],
-  Array [
-    "this",
-    "id1,1",
-  ],
-  Array [
-    "this",
-    "id2,1",
-  ],
-  Array [
-    "this",
-    "id3,1",
-  ],
-]
-`;
+exports[`Test a search of test1 ix file Search for "for this" in test1/myTrix.ix 1`] = `Array []`;
 
 exports[`Test a search of test1 ix file Search for "id1" in test1/myTrix.ix 1`] = `
 Array [
@@ -74,50 +32,7 @@ Array [
 
 exports[`Test a search of test1 ix file Search for "nope" in test1/myTrix.ix 1`] = `Array []`;
 
-exports[`Test a search of test1 ix file Search for "this is for id2" in test1/myTrix.ix 1`] = `
-Array [
-  Array [
-    "this",
-    "id1,1",
-  ],
-  Array [
-    "this",
-    "id2,1",
-  ],
-  Array [
-    "this",
-    "id3,1",
-  ],
-  Array [
-    "is",
-    "id1,2",
-  ],
-  Array [
-    "is",
-    "id2,2",
-  ],
-  Array [
-    "is",
-    "id3,2",
-  ],
-  Array [
-    "for",
-    "id1,4",
-  ],
-  Array [
-    "for",
-    "id2,4",
-  ],
-  Array [
-    "for",
-    "id3,4",
-  ],
-  Array [
-    "id2",
-    "id2,5",
-  ],
-]
-`;
+exports[`Test a search of test1 ix file Search for "this is for id2" in test1/myTrix.ix 1`] = `Array []`;
 
 exports[`Test a search of test1 ix file Search for "this" in test1/myTrix.ix 1`] = `
 Array [
@@ -136,359 +51,15 @@ Array [
 ]
 `;
 
-exports[`Test a search of test2 ix file Search for "FocAd" in test2/out.ix 1`] = `
-Array [
-  Array [
-    "focad-as1",
-    "ENST00000439876.1,1",
-  ],
-  Array [
-    "focad-as1",
-    "ENST00000445051.1,1",
-  ],
-]
-`;
+exports[`Test a search of test2 ix file Search for "FocAd" in test2/out.ix 1`] = `Array []`;
 
-exports[`Test a search of test2 ix file Search for "LINC" in test2/out.ix 1`] = `
-Array [
-  Array [
-    "linc-pint",
-    "ENST00000416999.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000423414.5,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000429901.2,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000431189.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000433079.5,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000435523.5,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000443623.5,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000451786.5,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000642156.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000642483.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000642602.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000643135.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000643373.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000643855.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000643874.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000644188.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000644804.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000645248.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000646429.1,1",
-  ],
-  Array [
-    "linc-pint",
-    "ENST00000646587.1,1",
-  ],
-]
-`;
+exports[`Test a search of test2 ix file Search for "LINC" in test2/out.ix 1`] = `Array []`;
 
-exports[`Test a search of test2 ix file Search for "enst ac" in test2/out.ix 1`] = `
-Array [
-  Array [
-    "enst00000229465.10",
-    "ENST00000229465.10,2",
-  ],
-  Array [
-    "enst00000230113.5",
-    "ENST00000230113.5,2",
-  ],
-  Array [
-    "enst00000235290.7",
-    "ENST00000235290.7,2",
-  ],
-  Array [
-    "enst00000242109.5",
-    "ENST00000242109.5,2",
-  ],
-  Array [
-    "enst00000244820.2",
-    "ENST00000244820.2,2",
-  ],
-  Array [
-    "enst00000244906.6",
-    "ENST00000244906.6,2",
-  ],
-  Array [
-    "enst00000248980.9",
-    "ENST00000248980.9,2",
-  ],
-  Array [
-    "enst00000250776.5",
-    "ENST00000250776.5,2",
-  ],
-  Array [
-    "enst00000250805.5",
-    "ENST00000250805.5,2",
-  ],
-  Array [
-    "enst00000253838.3",
-    "ENST00000253838.3,2",
-  ],
-  Array [
-    "enst00000253848.3",
-    "ENST00000253848.3,2",
-  ],
-  Array [
-    "enst00000255183.8",
-    "ENST00000255183.8,2",
-  ],
-  Array [
-    "enst00000262354.5",
-    "ENST00000262354.5,2",
-  ],
-  Array [
-    "enst00000276770.8",
-    "ENST00000276770.8,2",
-  ],
-  Array [
-    "enst00000276779.8",
-    "ENST00000276779.8,2",
-  ],
-  Array [
-    "enst00000279067.3",
-    "ENST00000279067.3,2",
-  ],
-  Array [
-    "enst00000289890.7",
-    "ENST00000289890.7,2",
-  ],
-  Array [
-    "enst00000291374.11",
-    "ENST00000291374.11,2",
-  ],
-  Array [
-    "enst00000292748.7",
-    "ENST00000292748.7,2",
-  ],
-  Array [
-    "enst00000294715.6",
-    "ENST00000294715.6,2",
-  ],
-]
-`;
+exports[`Test a search of test2 ix file Search for "enst ac" in test2/out.ix 1`] = `Array []`;
 
-exports[`Test a search of test2 ix file Search for "enst alg" in test2/out.ix 1`] = `
-Array [
-  Array [
-    "enst00000229465.10",
-    "ENST00000229465.10,2",
-  ],
-  Array [
-    "enst00000230113.5",
-    "ENST00000230113.5,2",
-  ],
-  Array [
-    "enst00000235290.7",
-    "ENST00000235290.7,2",
-  ],
-  Array [
-    "enst00000242109.5",
-    "ENST00000242109.5,2",
-  ],
-  Array [
-    "enst00000244820.2",
-    "ENST00000244820.2,2",
-  ],
-  Array [
-    "enst00000244906.6",
-    "ENST00000244906.6,2",
-  ],
-  Array [
-    "enst00000248980.9",
-    "ENST00000248980.9,2",
-  ],
-  Array [
-    "enst00000250776.5",
-    "ENST00000250776.5,2",
-  ],
-  Array [
-    "enst00000250805.5",
-    "ENST00000250805.5,2",
-  ],
-  Array [
-    "enst00000253838.3",
-    "ENST00000253838.3,2",
-  ],
-  Array [
-    "enst00000253848.3",
-    "ENST00000253848.3,2",
-  ],
-  Array [
-    "enst00000255183.8",
-    "ENST00000255183.8,2",
-  ],
-  Array [
-    "enst00000262354.5",
-    "ENST00000262354.5,2",
-  ],
-  Array [
-    "enst00000276770.8",
-    "ENST00000276770.8,2",
-  ],
-  Array [
-    "enst00000276779.8",
-    "ENST00000276779.8,2",
-  ],
-  Array [
-    "enst00000279067.3",
-    "ENST00000279067.3,2",
-  ],
-  Array [
-    "enst00000289890.7",
-    "ENST00000289890.7,2",
-  ],
-  Array [
-    "enst00000291374.11",
-    "ENST00000291374.11,2",
-  ],
-  Array [
-    "enst00000292748.7",
-    "ENST00000292748.7,2",
-  ],
-  Array [
-    "enst00000294715.6",
-    "ENST00000294715.6,2",
-  ],
-]
-`;
+exports[`Test a search of test2 ix file Search for "enst alg" in test2/out.ix 1`] = `Array []`;
 
-exports[`Test a search of test2 ix file Search for "enst" in test2/out.ix 1`] = `
-Array [
-  Array [
-    "enst00000229465.10",
-    "ENST00000229465.10,2",
-  ],
-  Array [
-    "enst00000230113.5",
-    "ENST00000230113.5,2",
-  ],
-  Array [
-    "enst00000235290.7",
-    "ENST00000235290.7,2",
-  ],
-  Array [
-    "enst00000242109.5",
-    "ENST00000242109.5,2",
-  ],
-  Array [
-    "enst00000244820.2",
-    "ENST00000244820.2,2",
-  ],
-  Array [
-    "enst00000244906.6",
-    "ENST00000244906.6,2",
-  ],
-  Array [
-    "enst00000248980.9",
-    "ENST00000248980.9,2",
-  ],
-  Array [
-    "enst00000250776.5",
-    "ENST00000250776.5,2",
-  ],
-  Array [
-    "enst00000250805.5",
-    "ENST00000250805.5,2",
-  ],
-  Array [
-    "enst00000253838.3",
-    "ENST00000253838.3,2",
-  ],
-  Array [
-    "enst00000253848.3",
-    "ENST00000253848.3,2",
-  ],
-  Array [
-    "enst00000255183.8",
-    "ENST00000255183.8,2",
-  ],
-  Array [
-    "enst00000262354.5",
-    "ENST00000262354.5,2",
-  ],
-  Array [
-    "enst00000276770.8",
-    "ENST00000276770.8,2",
-  ],
-  Array [
-    "enst00000276779.8",
-    "ENST00000276779.8,2",
-  ],
-  Array [
-    "enst00000279067.3",
-    "ENST00000279067.3,2",
-  ],
-  Array [
-    "enst00000289890.7",
-    "ENST00000289890.7,2",
-  ],
-  Array [
-    "enst00000291374.11",
-    "ENST00000291374.11,2",
-  ],
-  Array [
-    "enst00000292748.7",
-    "ENST00000292748.7,2",
-  ],
-  Array [
-    "enst00000294715.6",
-    "ENST00000294715.6,2
-enst00000295012.5",
-  ],
-]
-`;
+exports[`Test a search of test2 ix file Search for "enst" in test2/out.ix 1`] = `Array []`;
 
 exports[`Test a search of test2 ix file Search for "none" in test2/out.ix 1`] = `Array []`;
 
@@ -784,8 +355,7 @@ Array [
   ],
   Array [
     "timeless",
-    "ENSMUST00000146945.2,1
-timm10",
+    "ENSMUST00000146945.2,1",
   ],
 ]
 `;
@@ -915,8 +485,7 @@ Array [
   ],
   Array [
     "ekak",
-    "id44,1
-ekakt",
+    "id44,1",
   ],
 ]
 `;
@@ -941,8 +510,7 @@ Array [
   ],
   Array [
     "timd4",
-    "ENSMUST00000068877.7,1
-timeless",
+    "ENSMUST00000068877.7,1",
   ],
 ]
 `;

--- a/test/__snapshots__/search.test.ts.snap
+++ b/test/__snapshots__/search.test.ts.snap
@@ -2,31 +2,73 @@
 
 exports[`Test a search of test1 ix file Search for "fOR" in test1/myTrix.ix 1`] = `
 Array [
-  "id1",
-  "id2",
-  "id3",
+  Array [
+    "for",
+    "id1,4",
+  ],
+  Array [
+    "for",
+    "id2,4",
+  ],
+  Array [
+    "for",
+    "id3,4",
+  ],
 ]
 `;
 
 exports[`Test a search of test1 ix file Search for "for this" in test1/myTrix.ix 1`] = `
 Array [
-  "id1",
-  "id2",
-  "id3",
+  Array [
+    "for",
+    "id1,4",
+  ],
+  Array [
+    "for",
+    "id2,4",
+  ],
+  Array [
+    "for",
+    "id3,4",
+  ],
+  Array [
+    "this",
+    "id1,1",
+  ],
+  Array [
+    "this",
+    "id2,1",
+  ],
+  Array [
+    "this",
+    "id3,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test1 ix file Search for "id1" in test1/myTrix.ix 1`] = `
 Array [
-  "id1",
+  Array [
+    "id1",
+    "id1,5",
+  ],
 ]
 `;
 
 exports[`Test a search of test1 ix file Search for "is" in test1/myTrix.ix 1`] = `
 Array [
-  "id1",
-  "id2",
-  "id3",
+  Array [
+    "is",
+    "id1,2",
+  ],
+  Array [
+    "is",
+    "id2,2",
+  ],
+  Array [
+    "is",
+    "id3,2",
+  ],
 ]
 `;
 
@@ -34,113 +76,417 @@ exports[`Test a search of test1 ix file Search for "nope" in test1/myTrix.ix 1`]
 
 exports[`Test a search of test1 ix file Search for "this is for id2" in test1/myTrix.ix 1`] = `
 Array [
-  "id2",
+  Array [
+    "this",
+    "id1,1",
+  ],
+  Array [
+    "this",
+    "id2,1",
+  ],
+  Array [
+    "this",
+    "id3,1",
+  ],
+  Array [
+    "is",
+    "id1,2",
+  ],
+  Array [
+    "is",
+    "id2,2",
+  ],
+  Array [
+    "is",
+    "id3,2",
+  ],
+  Array [
+    "for",
+    "id1,4",
+  ],
+  Array [
+    "for",
+    "id2,4",
+  ],
+  Array [
+    "for",
+    "id3,4",
+  ],
+  Array [
+    "id2",
+    "id2,5",
+  ],
 ]
 `;
 
 exports[`Test a search of test1 ix file Search for "this" in test1/myTrix.ix 1`] = `
 Array [
-  "id1",
-  "id2",
-  "id3",
+  Array [
+    "this",
+    "id1,1",
+  ],
+  Array [
+    "this",
+    "id2,1",
+  ],
+  Array [
+    "this",
+    "id3,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "FocAd" in test2/out.ix 1`] = `
 Array [
-  "ENST00000439876.1",
-  "ENST00000445051.1",
+  Array [
+    "focad-as1",
+    "ENST00000439876.1,1",
+  ],
+  Array [
+    "focad-as1",
+    "ENST00000445051.1,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "LINC" in test2/out.ix 1`] = `
 Array [
-  "ENST00000416999.1",
-  "ENST00000423414.5",
-  "ENST00000429901.2",
-  "ENST00000431189.1",
-  "ENST00000433079.5",
-  "ENST00000435523.5",
-  "ENST00000443623.5",
-  "ENST00000451786.5",
-  "ENST00000642156.1",
-  "ENST00000642483.1",
-  "ENST00000642602.1",
-  "ENST00000643135.1",
-  "ENST00000643373.1",
-  "ENST00000643855.1",
-  "ENST00000643874.1",
-  "ENST00000644188.1",
-  "ENST00000644804.1",
-  "ENST00000645248.1",
-  "ENST00000646429.1",
-  "ENST00000646587.1",
+  Array [
+    "linc-pint",
+    "ENST00000416999.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000423414.5,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000429901.2,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000431189.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000433079.5,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000435523.5,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000443623.5,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000451786.5,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000642156.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000642483.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000642602.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000643135.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000643373.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000643855.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000643874.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000644188.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000644804.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000645248.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000646429.1,1",
+  ],
+  Array [
+    "linc-pint",
+    "ENST00000646587.1,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "enst ac" in test2/out.ix 1`] = `
 Array [
-  "enst00000562538.1",
-  "enst00000634116.1",
-  "enst00000449652.1",
-  "enst00000661649.1",
-  "enst00000415249.1",
-  "enst00000456270.1",
-  "enst00000653602.1",
-  "enst00000668236.1",
-  "enst00000661747.1",
-  "enst00000452326.1",
-  "enst00000431090.1",
-  "enst00000608816.1",
-  "enst00000607934.1",
-  "enst00000658236.1",
-  "enst00000661478.1",
-  "enst00000664918.1",
-  "enst00000413812.1",
-  "enst00000450061.5",
-  "enst00000667616.1",
-  "enst00000656084.1",
+  Array [
+    "enst00000229465.10",
+    "ENST00000229465.10,2",
+  ],
+  Array [
+    "enst00000230113.5",
+    "ENST00000230113.5,2",
+  ],
+  Array [
+    "enst00000235290.7",
+    "ENST00000235290.7,2",
+  ],
+  Array [
+    "enst00000242109.5",
+    "ENST00000242109.5,2",
+  ],
+  Array [
+    "enst00000244820.2",
+    "ENST00000244820.2,2",
+  ],
+  Array [
+    "enst00000244906.6",
+    "ENST00000244906.6,2",
+  ],
+  Array [
+    "enst00000248980.9",
+    "ENST00000248980.9,2",
+  ],
+  Array [
+    "enst00000250776.5",
+    "ENST00000250776.5,2",
+  ],
+  Array [
+    "enst00000250805.5",
+    "ENST00000250805.5,2",
+  ],
+  Array [
+    "enst00000253838.3",
+    "ENST00000253838.3,2",
+  ],
+  Array [
+    "enst00000253848.3",
+    "ENST00000253848.3,2",
+  ],
+  Array [
+    "enst00000255183.8",
+    "ENST00000255183.8,2",
+  ],
+  Array [
+    "enst00000262354.5",
+    "ENST00000262354.5,2",
+  ],
+  Array [
+    "enst00000276770.8",
+    "ENST00000276770.8,2",
+  ],
+  Array [
+    "enst00000276779.8",
+    "ENST00000276779.8,2",
+  ],
+  Array [
+    "enst00000279067.3",
+    "ENST00000279067.3,2",
+  ],
+  Array [
+    "enst00000289890.7",
+    "ENST00000289890.7,2",
+  ],
+  Array [
+    "enst00000291374.11",
+    "ENST00000291374.11,2",
+  ],
+  Array [
+    "enst00000292748.7",
+    "ENST00000292748.7,2",
+  ],
+  Array [
+    "enst00000294715.6",
+    "ENST00000294715.6,2",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "enst alg" in test2/out.ix 1`] = `
 Array [
-  "enst00000430794.1",
-  "enst00000508969.2",
-  "enst00000511954.5",
-  "enst00000524714.1",
-  "enst00000525473.1",
-  "enst00000657407.1",
-  "enst00000661578.1",
-  "enst00000664227.1",
-  "enst00000665956.1",
-  "enst00000670269.1",
-  "enst00000531305.1",
+  Array [
+    "enst00000229465.10",
+    "ENST00000229465.10,2",
+  ],
+  Array [
+    "enst00000230113.5",
+    "ENST00000230113.5,2",
+  ],
+  Array [
+    "enst00000235290.7",
+    "ENST00000235290.7,2",
+  ],
+  Array [
+    "enst00000242109.5",
+    "ENST00000242109.5,2",
+  ],
+  Array [
+    "enst00000244820.2",
+    "ENST00000244820.2,2",
+  ],
+  Array [
+    "enst00000244906.6",
+    "ENST00000244906.6,2",
+  ],
+  Array [
+    "enst00000248980.9",
+    "ENST00000248980.9,2",
+  ],
+  Array [
+    "enst00000250776.5",
+    "ENST00000250776.5,2",
+  ],
+  Array [
+    "enst00000250805.5",
+    "ENST00000250805.5,2",
+  ],
+  Array [
+    "enst00000253838.3",
+    "ENST00000253838.3,2",
+  ],
+  Array [
+    "enst00000253848.3",
+    "ENST00000253848.3,2",
+  ],
+  Array [
+    "enst00000255183.8",
+    "ENST00000255183.8,2",
+  ],
+  Array [
+    "enst00000262354.5",
+    "ENST00000262354.5,2",
+  ],
+  Array [
+    "enst00000276770.8",
+    "ENST00000276770.8,2",
+  ],
+  Array [
+    "enst00000276779.8",
+    "ENST00000276779.8,2",
+  ],
+  Array [
+    "enst00000279067.3",
+    "ENST00000279067.3,2",
+  ],
+  Array [
+    "enst00000289890.7",
+    "ENST00000289890.7,2",
+  ],
+  Array [
+    "enst00000291374.11",
+    "ENST00000291374.11,2",
+  ],
+  Array [
+    "enst00000292748.7",
+    "ENST00000292748.7,2",
+  ],
+  Array [
+    "enst00000294715.6",
+    "ENST00000294715.6,2",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "enst" in test2/out.ix 1`] = `
 Array [
-  "ENST00000229465.10",
-  "ENST00000230113.5",
-  "ENST00000235290.7",
-  "ENST00000242109.5",
-  "ENST00000244820.2",
-  "ENST00000244906.6",
-  "ENST00000248980.9",
-  "ENST00000250776.5",
-  "ENST00000250805.5",
-  "ENST00000253838.3",
-  "ENST00000253848.3",
-  "ENST00000255183.8",
-  "ENST00000262354.5",
-  "ENST00000276770.8",
-  "ENST00000276779.8",
-  "ENST00000279067.3",
-  "ENST00000289890.7",
-  "ENST00000291374.11",
-  "ENST00000292748.7",
-  "ENST00000294715.6",
+  Array [
+    "enst00000229465.10",
+    "ENST00000229465.10,2",
+  ],
+  Array [
+    "enst00000230113.5",
+    "ENST00000230113.5,2",
+  ],
+  Array [
+    "enst00000235290.7",
+    "ENST00000235290.7,2",
+  ],
+  Array [
+    "enst00000242109.5",
+    "ENST00000242109.5,2",
+  ],
+  Array [
+    "enst00000244820.2",
+    "ENST00000244820.2,2",
+  ],
+  Array [
+    "enst00000244906.6",
+    "ENST00000244906.6,2",
+  ],
+  Array [
+    "enst00000248980.9",
+    "ENST00000248980.9,2",
+  ],
+  Array [
+    "enst00000250776.5",
+    "ENST00000250776.5,2",
+  ],
+  Array [
+    "enst00000250805.5",
+    "ENST00000250805.5,2",
+  ],
+  Array [
+    "enst00000253838.3",
+    "ENST00000253838.3,2",
+  ],
+  Array [
+    "enst00000253848.3",
+    "ENST00000253848.3,2",
+  ],
+  Array [
+    "enst00000255183.8",
+    "ENST00000255183.8,2",
+  ],
+  Array [
+    "enst00000262354.5",
+    "ENST00000262354.5,2",
+  ],
+  Array [
+    "enst00000276770.8",
+    "ENST00000276770.8,2",
+  ],
+  Array [
+    "enst00000276779.8",
+    "ENST00000276779.8,2",
+  ],
+  Array [
+    "enst00000279067.3",
+    "ENST00000279067.3,2",
+  ],
+  Array [
+    "enst00000289890.7",
+    "ENST00000289890.7,2",
+  ],
+  Array [
+    "enst00000291374.11",
+    "ENST00000291374.11,2",
+  ],
+  Array [
+    "enst00000292748.7",
+    "ENST00000292748.7,2",
+  ],
+  Array [
+    "enst00000294715.6",
+    "ENST00000294715.6,2
+enst00000295012.5",
+  ],
 ]
 `;
 
@@ -148,44 +494,113 @@ exports[`Test a search of test2 ix file Search for "none" in test2/out.ix 1`] = 
 
 exports[`Test a search of test2 ix file Search for "prickle" in test2/out.ix 1`] = `
 Array [
-  "ENST00000460946.1",
-  "ENST00000476308.1",
-  "ENST00000484703.1",
-  "ENST00000473434.1",
-  "ENST00000487097.1",
-  "ENST00000659263.1",
+  Array [
+    "prickle2-as1",
+    "ENST00000460946.1,1",
+  ],
+  Array [
+    "prickle2-as1",
+    "ENST00000476308.1,1",
+  ],
+  Array [
+    "prickle2-as2",
+    "ENST00000484703.1,1",
+  ],
+  Array [
+    "prickle2-as3",
+    "ENST00000473434.1,1",
+  ],
+  Array [
+    "prickle2-dt",
+    "ENST00000487097.1,1",
+  ],
+  Array [
+    "prickle2-dt",
+    "ENST00000659263.1,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "tim" in test2/out.ix 1`] = `
 Array [
-  "ENST00000429104.1",
-  "ENST00000444438.2",
-  "ENST00000651208.1",
-  "ENST00000651763.1",
+  Array [
+    "timm23b-agap6",
+    "ENST00000429104.1,1",
+  ],
+  Array [
+    "timm23b-agap6",
+    "ENST00000444438.2,1",
+  ],
+  Array [
+    "timm23b-agap6",
+    "ENST00000651208.1,1",
+  ],
+  Array [
+    "timm23b-agap6",
+    "ENST00000651763.1,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test2 ix file Search for "znf8" in test2/out.ix 1`] = `
 Array [
-  "ENST00000591325.1",
-  "ENST00000443154.3",
-  "ENST00000592296.5",
+  Array [
+    "znf8-ervk3-1",
+    "ENST00000591325.1,1",
+  ],
+  Array [
+    "znf84-dt",
+    "ENST00000443154.3,1",
+  ],
+  Array [
+    "znf84-dt",
+    "ENST00000592296.5,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test3 ix file Search for "focad" in test3/out.ix 1`] = `
 Array [
-  "ENSMUST00000097992.10",
-  "ENSMUST00000107147.2",
-  "ENSMUST00000107148.8",
-  "ENSMUST00000129967.2",
-  "ENSMUST00000130603.2",
-  "ENSMUST00000144388.2",
-  "ENSMUST00000147527.2",
-  "ENSMUST00000159342.8",
-  "ENSMUST00000161058.8",
-  "ENSMUST00000162039.2",
+  Array [
+    "focad",
+    "ENSMUST00000097992.10,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000107147.2,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000107148.8,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000129967.2,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000130603.2,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000144388.2,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000147527.2,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000159342.8,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000161058.8,1",
+  ],
+  Array [
+    "focad",
+    "ENSMUST00000162039.2,1",
+  ],
 ]
 `;
 
@@ -193,107 +608,341 @@ exports[`Test a search of test3 ix file Search for "nothing" in test3/out.ix 1`]
 
 exports[`Test a search of test3 ix file Search for "oca" in test3/out.ix 1`] = `
 Array [
-  "ENSMUST00000032633.12",
-  "ENSMUST00000144739.8",
-  "ENSMUST00000152693.8",
-  "ENSMUST00000154559.2",
-  "ENSMUST00000155533.2",
-  "ENSMUST00000156886.8",
+  Array [
+    "oca2",
+    "ENSMUST00000032633.12,1",
+  ],
+  Array [
+    "oca2",
+    "ENSMUST00000144739.8,1",
+  ],
+  Array [
+    "oca2",
+    "ENSMUST00000152693.8,1",
+  ],
+  Array [
+    "oca2",
+    "ENSMUST00000154559.2,1",
+  ],
+  Array [
+    "oca2",
+    "ENSMUST00000155533.2,1",
+  ],
+  Array [
+    "oca2",
+    "ENSMUST00000156886.8,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test3 ix file Search for "prickle" in test3/out.ix 1`] = `
 Array [
-  "ENSMUST00000048982.11",
-  "ENSMUST00000109255.3",
-  "ENSMUST00000032093.12",
-  "ENSMUST00000113445.2",
-  "ENSMUST00000113446.8",
-  "ENSMUST00000113447.8",
-  "ENSMUST00000033485.14",
-  "ENSMUST00000123172.3",
-  "ENSMUST00000129662.3",
-  "ENSMUST00000141876.2",
-  "ENSMUST00000153994.2",
-  "ENSMUST00000113299.6",
-  "ENSMUST00000113300.8",
-  "ENSMUST00000142014.2",
-  "ENSMUST00000151540.2",
-  "ENSMUST00000152214.4",
+  Array [
+    "prickle1",
+    "ENSMUST00000048982.11,1",
+  ],
+  Array [
+    "prickle1",
+    "ENSMUST00000109255.3,1",
+  ],
+  Array [
+    "prickle2",
+    "ENSMUST00000032093.12,1",
+  ],
+  Array [
+    "prickle2",
+    "ENSMUST00000113445.2,1",
+  ],
+  Array [
+    "prickle2",
+    "ENSMUST00000113446.8,1",
+  ],
+  Array [
+    "prickle2",
+    "ENSMUST00000113447.8,1",
+  ],
+  Array [
+    "prickle3",
+    "ENSMUST00000033485.14,1",
+  ],
+  Array [
+    "prickle3",
+    "ENSMUST00000123172.3,1",
+  ],
+  Array [
+    "prickle3",
+    "ENSMUST00000129662.3,1",
+  ],
+  Array [
+    "prickle3",
+    "ENSMUST00000141876.2,1",
+  ],
+  Array [
+    "prickle3",
+    "ENSMUST00000153994.2,1",
+  ],
+  Array [
+    "prickle4",
+    "ENSMUST00000113299.6,1",
+  ],
+  Array [
+    "prickle4",
+    "ENSMUST00000113300.8,1",
+  ],
+  Array [
+    "prickle4",
+    "ENSMUST00000142014.2,1",
+  ],
+  Array [
+    "prickle4",
+    "ENSMUST00000151540.2,1",
+  ],
+  Array [
+    "prickle4",
+    "ENSMUST00000152214.4,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test3 ix file Search for "tim" in test3/out.ix 1`] = `
 Array [
-  "ENSMUST00000055102.13",
-  "ENSMUST00000109225.9",
-  "ENSMUST00000125008.2",
-  "ENSMUST00000169584.8",
-  "ENSMUST00000068877.7",
-  "ENSMUST00000055539.11",
-  "ENSMUST00000105240.8",
-  "ENSMUST00000105242.8",
-  "ENSMUST00000105243.9",
-  "ENSMUST00000105244.8",
-  "ENSMUST00000105245.3",
-  "ENSMUST00000125289.8",
-  "ENSMUST00000129147.2",
-  "ENSMUST00000135376.2",
-  "ENSMUST00000135538.2",
-  "ENSMUST00000136854.2",
-  "ENSMUST00000142149.2",
-  "ENSMUST00000142484.2",
-  "ENSMUST00000145710.8",
-  "ENSMUST00000146945.2",
+  Array [
+    "timd2",
+    "ENSMUST00000055102.13,1",
+  ],
+  Array [
+    "timd2",
+    "ENSMUST00000109225.9,1",
+  ],
+  Array [
+    "timd2",
+    "ENSMUST00000125008.2,1",
+  ],
+  Array [
+    "timd2",
+    "ENSMUST00000169584.8,1",
+  ],
+  Array [
+    "timd4",
+    "ENSMUST00000068877.7,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000055539.11,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000105240.8,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000105242.8,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000105243.9,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000105244.8,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000105245.3,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000125289.8,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000129147.2,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000135376.2,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000135538.2,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000136854.2,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000142149.2,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000142484.2,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000145710.8,1",
+  ],
+  Array [
+    "timeless",
+    "ENSMUST00000146945.2,1
+timm10",
+  ],
 ]
 `;
 
 exports[`Test a search of test3 ix file Search for "zzz" in test3/out.ix 1`] = `
 Array [
-  "ENSMUST00000089982.11",
-  "ENSMUST00000106100.9",
-  "ENSMUST00000106101.2",
-  "ENSMUST00000106103.8",
-  "ENSMUST00000135044.3",
-  "ENSMUST00000138115.8",
-  "ENSMUST00000150802.8",
-  "ENSMUST00000197987.5",
-  "ENSMUST00000198468.2",
-  "ENSMUST00000200570.5",
+  Array [
+    "zzz3",
+    "ENSMUST00000089982.11,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000106100.9,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000106101.2,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000106103.8,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000135044.3,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000138115.8,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000150802.8,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000197987.5,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000198468.2,1",
+  ],
+  Array [
+    "zzz3",
+    "ENSMUST00000200570.5,1",
+  ],
 ]
 `;
 
 exports[`Test a search of test4 ix file Search for "ek" in test4/out.ix 1`] = `
 Array [
-  "id11",
-  "id8",
-  "id12",
-  "id13",
-  "id14",
-  "id46",
-  "id39",
-  "id41",
-  "id16",
-  "id1",
-  "id17",
-  "id9",
-  "id18",
-  "id19",
-  "id10",
-  "id2",
-  "id20",
-  "id26",
-  "id4",
-  "id44",
+  Array [
+    "ekaa",
+    "id11,1",
+  ],
+  Array [
+    "ekaa",
+    "id8,1",
+  ],
+  Array [
+    "ekab",
+    "id12,1",
+  ],
+  Array [
+    "ekac",
+    "id13,1",
+  ],
+  Array [
+    "ekad",
+    "id14,1",
+  ],
+  Array [
+    "ekadd",
+    "id46,1",
+  ],
+  Array [
+    "ekae",
+    "id39,1",
+  ],
+  Array [
+    "ekaf",
+    "id41,1",
+  ],
+  Array [
+    "ekag",
+    "id16,1",
+  ],
+  Array [
+    "ekah",
+    "id1,1",
+  ],
+  Array [
+    "ekah",
+    "id17,1",
+  ],
+  Array [
+    "ekah",
+    "id9,1",
+  ],
+  Array [
+    "ekai",
+    "id18,1",
+  ],
+  Array [
+    "ekaj",
+    "id19,1",
+  ],
+  Array [
+    "ekak",
+    "id10,1",
+  ],
+  Array [
+    "ekak",
+    "id2,1",
+  ],
+  Array [
+    "ekak",
+    "id20,1",
+  ],
+  Array [
+    "ekak",
+    "id26,1",
+  ],
+  Array [
+    "ekak",
+    "id4,1",
+  ],
+  Array [
+    "ekak",
+    "id44,1
+ekakt",
+  ],
 ]
 `;
 
 exports[`Test maxResults for search of test3 ix file Search for "tim" with a max of 5 results 1`] = `
 Array [
-  "ENSMUST00000055102.13",
-  "ENSMUST00000109225.9",
-  "ENSMUST00000125008.2",
-  "ENSMUST00000169584.8",
-  "ENSMUST00000068877.7",
+  Array [
+    "timd2",
+    "ENSMUST00000055102.13,1",
+  ],
+  Array [
+    "timd2",
+    "ENSMUST00000109225.9,1",
+  ],
+  Array [
+    "timd2",
+    "ENSMUST00000125008.2,1",
+  ],
+  Array [
+    "timd2",
+    "ENSMUST00000169584.8,1",
+  ],
+  Array [
+    "timd4",
+    "ENSMUST00000068877.7,1
+timeless",
+  ],
 ]
 `;

--- a/test/__snapshots__/search.test.ts.snap
+++ b/test/__snapshots__/search.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Test a search of test1 ix file Search for "id1" in test1/myTrix.ix 1`] 
 Array [
   Array [
     "id1",
-    "id1,5",
+    "id1",
   ],
 ]
 `;
@@ -17,15 +17,15 @@ exports[`Test a search of test1 ix file Search for "is" in test1/myTrix.ix 1`] =
 Array [
   Array [
     "is",
-    "id1,2",
+    "id1",
   ],
   Array [
     "is",
-    "id2,2",
+    "id2",
   ],
   Array [
     "is",
-    "id3,2",
+    "id3",
   ],
 ]
 `;
@@ -38,15 +38,15 @@ exports[`Test a search of test1 ix file Search for "this" in test1/myTrix.ix 1`]
 Array [
   Array [
     "this",
-    "id1,1",
+    "id1",
   ],
   Array [
     "this",
-    "id2,1",
+    "id2",
   ],
   Array [
     "this",
-    "id3,1",
+    "id3",
   ],
 ]
 `;
@@ -67,27 +67,27 @@ exports[`Test a search of test2 ix file Search for "prickle" in test2/out.ix 1`]
 Array [
   Array [
     "prickle2-as1",
-    "ENST00000460946.1,1",
+    "ENST00000460946.1",
   ],
   Array [
     "prickle2-as1",
-    "ENST00000476308.1,1",
+    "ENST00000476308.1",
   ],
   Array [
     "prickle2-as2",
-    "ENST00000484703.1,1",
+    "ENST00000484703.1",
   ],
   Array [
     "prickle2-as3",
-    "ENST00000473434.1,1",
+    "ENST00000473434.1",
   ],
   Array [
     "prickle2-dt",
-    "ENST00000487097.1,1",
+    "ENST00000487097.1",
   ],
   Array [
     "prickle2-dt",
-    "ENST00000659263.1,1",
+    "ENST00000659263.1",
   ],
 ]
 `;
@@ -96,19 +96,19 @@ exports[`Test a search of test2 ix file Search for "tim" in test2/out.ix 1`] = `
 Array [
   Array [
     "timm23b-agap6",
-    "ENST00000429104.1,1",
+    "ENST00000429104.1",
   ],
   Array [
     "timm23b-agap6",
-    "ENST00000444438.2,1",
+    "ENST00000444438.2",
   ],
   Array [
     "timm23b-agap6",
-    "ENST00000651208.1,1",
+    "ENST00000651208.1",
   ],
   Array [
     "timm23b-agap6",
-    "ENST00000651763.1,1",
+    "ENST00000651763.1",
   ],
 ]
 `;
@@ -117,15 +117,15 @@ exports[`Test a search of test2 ix file Search for "znf8" in test2/out.ix 1`] = 
 Array [
   Array [
     "znf8-ervk3-1",
-    "ENST00000591325.1,1",
+    "ENST00000591325.1",
   ],
   Array [
     "znf84-dt",
-    "ENST00000443154.3,1",
+    "ENST00000443154.3",
   ],
   Array [
     "znf84-dt",
-    "ENST00000592296.5,1",
+    "ENST00000592296.5",
   ],
 ]
 `;
@@ -134,43 +134,43 @@ exports[`Test a search of test3 ix file Search for "focad" in test3/out.ix 1`] =
 Array [
   Array [
     "focad",
-    "ENSMUST00000097992.10,1",
+    "ENSMUST00000097992.10",
   ],
   Array [
     "focad",
-    "ENSMUST00000107147.2,1",
+    "ENSMUST00000107147.2",
   ],
   Array [
     "focad",
-    "ENSMUST00000107148.8,1",
+    "ENSMUST00000107148.8",
   ],
   Array [
     "focad",
-    "ENSMUST00000129967.2,1",
+    "ENSMUST00000129967.2",
   ],
   Array [
     "focad",
-    "ENSMUST00000130603.2,1",
+    "ENSMUST00000130603.2",
   ],
   Array [
     "focad",
-    "ENSMUST00000144388.2,1",
+    "ENSMUST00000144388.2",
   ],
   Array [
     "focad",
-    "ENSMUST00000147527.2,1",
+    "ENSMUST00000147527.2",
   ],
   Array [
     "focad",
-    "ENSMUST00000159342.8,1",
+    "ENSMUST00000159342.8",
   ],
   Array [
     "focad",
-    "ENSMUST00000161058.8,1",
+    "ENSMUST00000161058.8",
   ],
   Array [
     "focad",
-    "ENSMUST00000162039.2,1",
+    "ENSMUST00000162039.2",
   ],
 ]
 `;
@@ -181,27 +181,27 @@ exports[`Test a search of test3 ix file Search for "oca" in test3/out.ix 1`] = `
 Array [
   Array [
     "oca2",
-    "ENSMUST00000032633.12,1",
+    "ENSMUST00000032633.12",
   ],
   Array [
     "oca2",
-    "ENSMUST00000144739.8,1",
+    "ENSMUST00000144739.8",
   ],
   Array [
     "oca2",
-    "ENSMUST00000152693.8,1",
+    "ENSMUST00000152693.8",
   ],
   Array [
     "oca2",
-    "ENSMUST00000154559.2,1",
+    "ENSMUST00000154559.2",
   ],
   Array [
     "oca2",
-    "ENSMUST00000155533.2,1",
+    "ENSMUST00000155533.2",
   ],
   Array [
     "oca2",
-    "ENSMUST00000156886.8,1",
+    "ENSMUST00000156886.8",
   ],
 ]
 `;
@@ -210,67 +210,67 @@ exports[`Test a search of test3 ix file Search for "prickle" in test3/out.ix 1`]
 Array [
   Array [
     "prickle1",
-    "ENSMUST00000048982.11,1",
+    "ENSMUST00000048982.11",
   ],
   Array [
     "prickle1",
-    "ENSMUST00000109255.3,1",
+    "ENSMUST00000109255.3",
   ],
   Array [
     "prickle2",
-    "ENSMUST00000032093.12,1",
+    "ENSMUST00000032093.12",
   ],
   Array [
     "prickle2",
-    "ENSMUST00000113445.2,1",
+    "ENSMUST00000113445.2",
   ],
   Array [
     "prickle2",
-    "ENSMUST00000113446.8,1",
+    "ENSMUST00000113446.8",
   ],
   Array [
     "prickle2",
-    "ENSMUST00000113447.8,1",
+    "ENSMUST00000113447.8",
   ],
   Array [
     "prickle3",
-    "ENSMUST00000033485.14,1",
+    "ENSMUST00000033485.14",
   ],
   Array [
     "prickle3",
-    "ENSMUST00000123172.3,1",
+    "ENSMUST00000123172.3",
   ],
   Array [
     "prickle3",
-    "ENSMUST00000129662.3,1",
+    "ENSMUST00000129662.3",
   ],
   Array [
     "prickle3",
-    "ENSMUST00000141876.2,1",
+    "ENSMUST00000141876.2",
   ],
   Array [
     "prickle3",
-    "ENSMUST00000153994.2,1",
+    "ENSMUST00000153994.2",
   ],
   Array [
     "prickle4",
-    "ENSMUST00000113299.6,1",
+    "ENSMUST00000113299.6",
   ],
   Array [
     "prickle4",
-    "ENSMUST00000113300.8,1",
+    "ENSMUST00000113300.8",
   ],
   Array [
     "prickle4",
-    "ENSMUST00000142014.2,1",
+    "ENSMUST00000142014.2",
   ],
   Array [
     "prickle4",
-    "ENSMUST00000151540.2,1",
+    "ENSMUST00000151540.2",
   ],
   Array [
     "prickle4",
-    "ENSMUST00000152214.4,1",
+    "ENSMUST00000152214.4",
   ],
 ]
 `;
@@ -279,83 +279,83 @@ exports[`Test a search of test3 ix file Search for "tim" in test3/out.ix 1`] = `
 Array [
   Array [
     "timd2",
-    "ENSMUST00000055102.13,1",
+    "ENSMUST00000055102.13",
   ],
   Array [
     "timd2",
-    "ENSMUST00000109225.9,1",
+    "ENSMUST00000109225.9",
   ],
   Array [
     "timd2",
-    "ENSMUST00000125008.2,1",
+    "ENSMUST00000125008.2",
   ],
   Array [
     "timd2",
-    "ENSMUST00000169584.8,1",
+    "ENSMUST00000169584.8",
   ],
   Array [
     "timd4",
-    "ENSMUST00000068877.7,1",
+    "ENSMUST00000068877.7",
   ],
   Array [
     "timeless",
-    "ENSMUST00000055539.11,1",
+    "ENSMUST00000055539.11",
   ],
   Array [
     "timeless",
-    "ENSMUST00000105240.8,1",
+    "ENSMUST00000105240.8",
   ],
   Array [
     "timeless",
-    "ENSMUST00000105242.8,1",
+    "ENSMUST00000105242.8",
   ],
   Array [
     "timeless",
-    "ENSMUST00000105243.9,1",
+    "ENSMUST00000105243.9",
   ],
   Array [
     "timeless",
-    "ENSMUST00000105244.8,1",
+    "ENSMUST00000105244.8",
   ],
   Array [
     "timeless",
-    "ENSMUST00000105245.3,1",
+    "ENSMUST00000105245.3",
   ],
   Array [
     "timeless",
-    "ENSMUST00000125289.8,1",
+    "ENSMUST00000125289.8",
   ],
   Array [
     "timeless",
-    "ENSMUST00000129147.2,1",
+    "ENSMUST00000129147.2",
   ],
   Array [
     "timeless",
-    "ENSMUST00000135376.2,1",
+    "ENSMUST00000135376.2",
   ],
   Array [
     "timeless",
-    "ENSMUST00000135538.2,1",
+    "ENSMUST00000135538.2",
   ],
   Array [
     "timeless",
-    "ENSMUST00000136854.2,1",
+    "ENSMUST00000136854.2",
   ],
   Array [
     "timeless",
-    "ENSMUST00000142149.2,1",
+    "ENSMUST00000142149.2",
   ],
   Array [
     "timeless",
-    "ENSMUST00000142484.2,1",
+    "ENSMUST00000142484.2",
   ],
   Array [
     "timeless",
-    "ENSMUST00000145710.8,1",
+    "ENSMUST00000145710.8",
   ],
   Array [
     "timeless",
-    "ENSMUST00000146945.2,1",
+    "ENSMUST00000146945.2",
   ],
 ]
 `;
@@ -364,43 +364,43 @@ exports[`Test a search of test3 ix file Search for "zzz" in test3/out.ix 1`] = `
 Array [
   Array [
     "zzz3",
-    "ENSMUST00000089982.11,1",
+    "ENSMUST00000089982.11",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000106100.9,1",
+    "ENSMUST00000106100.9",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000106101.2,1",
+    "ENSMUST00000106101.2",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000106103.8,1",
+    "ENSMUST00000106103.8",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000135044.3,1",
+    "ENSMUST00000135044.3",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000138115.8,1",
+    "ENSMUST00000138115.8",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000150802.8,1",
+    "ENSMUST00000150802.8",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000197987.5,1",
+    "ENSMUST00000197987.5",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000198468.2,1",
+    "ENSMUST00000198468.2",
   ],
   Array [
     "zzz3",
-    "ENSMUST00000200570.5,1",
+    "ENSMUST00000200570.5",
   ],
 ]
 `;
@@ -409,83 +409,83 @@ exports[`Test a search of test4 ix file Search for "ek" in test4/out.ix 1`] = `
 Array [
   Array [
     "ekaa",
-    "id11,1",
+    "id11",
   ],
   Array [
     "ekaa",
-    "id8,1",
+    "id8",
   ],
   Array [
     "ekab",
-    "id12,1",
+    "id12",
   ],
   Array [
     "ekac",
-    "id13,1",
+    "id13",
   ],
   Array [
     "ekad",
-    "id14,1",
+    "id14",
   ],
   Array [
     "ekadd",
-    "id46,1",
+    "id46",
   ],
   Array [
     "ekae",
-    "id39,1",
+    "id39",
   ],
   Array [
     "ekaf",
-    "id41,1",
+    "id41",
   ],
   Array [
     "ekag",
-    "id16,1",
+    "id16",
   ],
   Array [
     "ekah",
-    "id1,1",
+    "id1",
   ],
   Array [
     "ekah",
-    "id17,1",
+    "id17",
   ],
   Array [
     "ekah",
-    "id9,1",
+    "id9",
   ],
   Array [
     "ekai",
-    "id18,1",
+    "id18",
   ],
   Array [
     "ekaj",
-    "id19,1",
+    "id19",
   ],
   Array [
     "ekak",
-    "id10,1",
+    "id10",
   ],
   Array [
     "ekak",
-    "id2,1",
+    "id2",
   ],
   Array [
     "ekak",
-    "id20,1",
+    "id20",
   ],
   Array [
     "ekak",
-    "id26,1",
+    "id26",
   ],
   Array [
     "ekak",
-    "id4,1",
+    "id4",
   ],
   Array [
     "ekak",
-    "id44,1",
+    "id44",
   ],
 ]
 `;
@@ -494,23 +494,23 @@ exports[`Test maxResults for search of test3 ix file Search for "tim" with a max
 Array [
   Array [
     "timd2",
-    "ENSMUST00000055102.13,1",
+    "ENSMUST00000055102.13",
   ],
   Array [
     "timd2",
-    "ENSMUST00000109225.9,1",
+    "ENSMUST00000109225.9",
   ],
   Array [
     "timd2",
-    "ENSMUST00000125008.2,1",
+    "ENSMUST00000125008.2",
   ],
   Array [
     "timd2",
-    "ENSMUST00000169584.8,1",
+    "ENSMUST00000169584.8",
   ],
   Array [
     "timd4",
-    "ENSMUST00000068877.7,1",
+    "ENSMUST00000068877.7",
   ],
 ]
 `;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es2017", "es7", "es6", "dom"],
+    "lib": ["es2019", "es7", "es6", "dom"],
     "outDir": "dist",
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
This is a redo of #6 

This proposes returning the matched trix term with the search results

The aim is to improve the comprehensibility of the results

With this the search results can include the trix matched term like this, a search for kinase matches EDEN

![Screenshot from 2021-09-03 14-03-42](https://user-images.githubusercontent.com/6511937/132048482-26e4c988-61ee-4743-a28d-d09339aba0c8.png)
